### PR TITLE
fix bug when num contains regexp special chars

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,9 +84,14 @@ const convertBase = (
     throw new Error("Second augument must not contain the same characters.");
   }
 
-  const availableCharacters = new RegExp("^[" + originalBase + "]+$");
-  if (!availableCharacters.test(num)) {
+  if(num.length === 0) {
     throw new Error("First augument must consist of second augument.");
+  }
+
+  for(let i = 0; i < num.length; i++) {
+    if(!originalBase.includes(num.charAt(i))) {
+        throw new Error("First augument must consist of second augument.");
+    }
   }
 
   if (typeof newBase !== "number" && typeof newBase !== "string") {


### PR DESCRIPTION
Closes #15 

When the base string contains regexp breaking characters such as `[]\-` the validation fails if one of these characters is in the string to be converted. This can be fixed by either replacing all characters that need escaping with the escaped version or by not using a regular expression to do this check. I think not using a regular expression is the more robust option.