### PR TITLE
Migrate npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -35,6 +35,9 @@ jobs:
   version-and-publish:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -48,9 +51,7 @@ jobs:
       - run: pnpm version ${{ inputs.version || 'patch' }} -m "v%s [skip ci]"
       - run: git push origin HEAD --tags
       - run: pnpm install --frozen-lockfile
-      - run: pnpm publish --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - run: pnpm publish --no-git-checks --provenance
       - run: gh release create "v$(node -p 'require("./package.json").version')" --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- npm publishをトークンベースからOIDC trusted publishingに移行
- `NPM_AUTH_TOKEN` シークレット不要に
- `--provenance` フラグ追加でパッケージの出所を証明

## Test plan

- [ ] trusted publishingでnpm publishが成功すること
- [ ] GitHub Releaseが自動生成されること