### PR TITLE
Fix trusted publishing: remove registry-url to avoid token conflict

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -44,14 +44,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
-          registry-url: https://registry.npmjs.org/
           cache: pnpm
       - run: git config --global user.name "WATANABE Shin"
       - run: git config --global user.email "sin9270@gmail.com"
       - run: pnpm version ${{ inputs.version || 'patch' }} -m "v%s [skip ci]"
       - run: git push origin HEAD --tags
       - run: pnpm install --frozen-lockfile
-      - run: pnpm publish --no-git-checks --provenance
+      - run: npm publish --provenance --access public
       - run: gh release create "v$(node -p 'require("./package.json").version')" --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `setup-node` から `registry-url` を削除（`.npmrc` に無効なトークンが書かれるのを防止）
- `npm publish --provenance --access public` でOIDC trusted publishingを直接使用

## Test plan

- [ ] npm publishが成功すること