### PR TITLE
Fix trusted publishing: restore registry-url with empty token

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
+          registry-url: https://registry.npmjs.org/
           cache: pnpm
       - run: git config --global user.name "WATANABE Shin"
       - run: git config --global user.email "sin9270@gmail.com"
@@ -51,6 +52,8 @@ jobs:
       - run: git push origin HEAD --tags
       - run: pnpm install --frozen-lockfile
       - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ""
       - run: gh release create "v$(node -p 'require("./package.json").version')" --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `registry-url` を復元（レジストリ設定が必要）
- `NODE_AUTH_TOKEN` を明示的に空で設定し、OIDC認証にフォールバックさせる

## Test plan

- [ ] npm publishが成功すること