### PR TITLE
Fix trusted publishing: upgrade npm for OIDC support

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -46,14 +46,13 @@ jobs:
           node-version: "22.x"
           registry-url: https://registry.npmjs.org/
           cache: pnpm
+      - run: npm install -g npm@latest
       - run: git config --global user.name "WATANABE Shin"
       - run: git config --global user.email "sin9270@gmail.com"
       - run: pnpm version ${{ inputs.version || 'patch' }} -m "v%s [skip ci]"
       - run: git push origin HEAD --tags
       - run: pnpm install --frozen-lockfile
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ""
       - run: gh release create "v$(node -p 'require("./package.json").version')" --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `npm install -g npm@latest` を追加（OIDC認証にはnpm 11.5.1+が必要）
- `NODE_AUTH_TOKEN` を削除（OIDCが自動的に認証を処理）

## Test plan

- [ ] npm publishが成功すること