### PR TITLE
Fix npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -43,10 +43,8 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
-          registry-url: https://registry.npmjs.org/
+          node-version: "24.x"
           cache: pnpm
-      - run: npm install -g npm@latest
       - run: git config --global user.name "WATANABE Shin"
       - run: git config --global user.email "sin9270@gmail.com"
       - run: pnpm version ${{ inputs.version || 'patch' }} -m "v%s [skip ci]"


### PR DESCRIPTION
## Summary
- `actions/setup-node` の `registry-url` を削除し、npm OIDC認証を有効化
- `registry-url` が `.npmrc` に `_authToken=${NODE_AUTH_TOKEN}` を書き込み、空トークンで `ENEEDAUTH` エラーを引き起こしていた
- 不要な `npm install -g npm@latest`（MODULE_NOT_FOUND の原因）と `npm config set registry`（デフォルトで正しい）も削除

## Root Cause
`actions/setup-node@v4` に `registry-url` を指定すると、`.npmrc` にトークン参照が書き込まれ、npm がOIDCにフォールバックせずトークン認証を試みる。トークンが空のため `ENEEDAUTH` で失敗していた。

## Test plan
- [ ] master マージ後、GitHub Actions の `npm publish` ステップが `ENEEDAUTH` なしで完了すること
- [ ] npm レジストリに新バージョンが publish されること
- [ ] npmjs.com の trusted publisher 設定で workflow filename が `npmpublish.yml` であること確認